### PR TITLE
feat: Shopee Trends UI — product card grid (#12)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -283,19 +283,20 @@
     .ticket-link:hover { text-decoration:underline; }
 
     /* === Trends === */
-    .trend-item { display:flex; align-items:center; gap:14px; padding:14px 16px; border:1px solid var(--border); border-radius:12px; margin-bottom:8px; transition:all 0.2s; background:var(--card); }
-    .trend-item:hover { border-color:rgba(239,68,68,0.2); background:rgba(239,68,68,0.02); }
-    .trend-rank { width:32px; height:32px; border-radius:10px; background:var(--input); display:flex; align-items:center; justify-content:center; font-size:0.82rem; font-weight:800; color:var(--muted); flex-shrink:0; }
-    .trend-rank.hot { background:linear-gradient(135deg,#ef4444,#f97316); color:white; box-shadow:0 2px 8px rgba(239,68,68,0.25); }
-    .trend-rank.warm { background:rgba(245,158,11,0.15); color:var(--warning); }
-    .trend-hashtags { display:flex; gap:4px; flex-wrap:wrap; margin-top:4px; }
-    .trend-chip { padding:2px 8px; background:rgba(79,110,247,0.08); border:1px solid rgba(79,110,247,0.15); border-radius:12px; font-size:0.68rem; color:var(--accent); cursor:pointer; transition:all 0.15s; font-family:inherit; }
-    .trend-chip:hover { background:var(--accent); color:white; border-color:var(--accent); }
-    .trend-body { flex: 1; min-width: 0; }
-    .trend-title { font-size: 0.9rem; font-weight: 600; color: var(--text); }
-    .trend-vol { font-size: 0.72rem; color: var(--text-muted); margin-top: 2px; }
-    .trend-btn { padding:8px 14px; border:none; border-radius:8px; background:var(--accent); color:white; font-size:0.78rem; font-weight:600; cursor:pointer; font-family:inherit; transition:all 0.2s; white-space:nowrap; flex-shrink:0; box-shadow:0 2px 8px var(--glow); }
-    .trend-btn:hover { background:#6380ff; transform:translateY(-1px); box-shadow:0 4px 12px var(--glow); }
+    .trend-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:10px; }
+    @media(min-width:640px){ .trend-grid { grid-template-columns:repeat(3,1fr); } }
+    @media(min-width:900px){ .trend-grid { grid-template-columns:repeat(4,1fr); } }
+    .trend-card { background:var(--bg-card); border:1px solid var(--border); border-radius:10px; overflow:hidden; transition:all 0.2s; cursor:pointer; }
+    .trend-card:hover { border-color:rgba(79,110,247,0.3); transform:translateY(-2px); box-shadow:0 4px 16px rgba(0,0,0,0.3); }
+    .trend-card-img { width:100%; aspect-ratio:1; object-fit:cover; background:var(--bg-input); }
+    .trend-card-body { padding:10px; }
+    .trend-card-name { font-size:0.78rem; font-weight:500; color:var(--text); display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; line-height:1.4; min-height:2.2em; }
+    .trend-card-price { font-size:0.85rem; font-weight:700; color:#ee4d2d; margin-top:6px; }
+    .trend-card-meta { display:flex; justify-content:space-between; align-items:center; margin-top:4px; font-size:0.65rem; color:var(--text-muted); }
+    .trend-card-stars { color:#f59e0b; }
+    .trend-card-sold { color:var(--text-muted); }
+    .trend-card-btn { display:block; width:100%; padding:7px; border:none; border-top:1px solid var(--border); background:transparent; color:var(--accent); font-size:0.72rem; font-weight:600; cursor:pointer; font-family:inherit; transition:background 0.15s; }
+    .trend-card-btn:hover { background:rgba(79,110,247,0.06); }
     .trend-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px; }
     .trend-refresh { padding: 6px 10px; border: none; background: rgba(255,255,255,0.04); border-radius: 6px; color: var(--text-muted); font-size: 0.75rem; cursor: pointer; font-family: inherit; transition: all 0.2s; }
     .trend-refresh:hover { background: rgba(255,255,255,0.08); color: var(--text-secondary); }
@@ -528,23 +529,19 @@
 
       <div id="tabTrends" class="hidden">
         <div class="card">
-          <div class="trend-header">
-            <div class="card-title" style="margin-bottom:0"><span class="card-title-icon">🔥</span> Trending in Thailand <span id="trendCount" style="font-size:0.75rem;color:var(--text-muted);font-weight:400"></span></div>
+          <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;flex-wrap:wrap;gap:6px">
+            <div class="card-title" style="margin-bottom:0"><span class="card-title-icon">🛒</span> สินค้าขายดี <span id="trendCount" style="font-size:0.75rem;color:var(--text-muted);font-weight:400"></span></div>
+            <button onclick="loadTrends()" style="padding:4px 10px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--text-muted);font-size:0.72rem;cursor:pointer;font-family:inherit">↻</button>
           </div>
           <div style="display:flex;gap:4px;margin:8px 0;flex-wrap:wrap" id="trendFilters">
             <button onclick="filterTrends('all')" class="trend-filter active" style="padding:4px 10px;border-radius:6px;font-size:0.72rem;border:1px solid var(--border);background:var(--accent);color:#fff;cursor:pointer">ทั้งหมด</button>
-            <button onclick="filterTrends('sports')" class="trend-filter" style="padding:4px 10px;border-radius:6px;font-size:0.72rem;border:1px solid var(--border);background:var(--bg-input);color:var(--text-secondary);cursor:pointer">กีฬา</button>
-            <button onclick="filterTrends('entertainment')" class="trend-filter" style="padding:4px 10px;border-radius:6px;font-size:0.72rem;border:1px solid var(--border);background:var(--bg-input);color:var(--text-secondary);cursor:pointer">บันเทิง</button>
-            <button onclick="filterTrends('news')" class="trend-filter" style="padding:4px 10px;border-radius:6px;font-size:0.72rem;border:1px solid var(--border);background:var(--bg-input);color:var(--text-secondary);cursor:pointer">ข่าว</button>
-            <button onclick="filterTrends('general')" class="trend-filter" style="padding:4px 10px;border-radius:6px;font-size:0.72rem;border:1px solid var(--border);background:var(--bg-input);color:var(--text-secondary);cursor:pointer">ทั่วไป</button>
+            <button onclick="filterTrends('fashion')" class="trend-filter" style="padding:4px 10px;border-radius:6px;font-size:0.72rem;border:1px solid var(--border);background:var(--bg-input);color:var(--text-secondary);cursor:pointer">แฟชั่น</button>
+            <button onclick="filterTrends('electronics')" class="trend-filter" style="padding:4px 10px;border-radius:6px;font-size:0.72rem;border:1px solid var(--border);background:var(--bg-input);color:var(--text-secondary);cursor:pointer">อิเล็กทรอนิกส์</button>
+            <button onclick="filterTrends('beauty')" class="trend-filter" style="padding:4px 10px;border-radius:6px;font-size:0.72rem;border:1px solid var(--border);background:var(--bg-input);color:var(--text-secondary);cursor:pointer">บิวตี้</button>
+            <button onclick="filterTrends('home')" class="trend-filter" style="padding:4px 10px;border-radius:6px;font-size:0.72rem;border:1px solid var(--border);background:var(--bg-input);color:var(--text-secondary);cursor:pointer">บ้าน</button>
+            <button onclick="filterTrends('health')" class="trend-filter" style="padding:4px 10px;border-radius:6px;font-size:0.72rem;border:1px solid var(--border);background:var(--bg-input);color:var(--text-secondary);cursor:pointer">สุขภาพ</button>
           </div>
-          <div style="display:none">
-            <div style="display:flex;align-items:center;gap:8px">
-              <span id="trendUpdated" style="font-size:0.68rem;color:var(--text-muted)"></span>
-              <button class="trend-refresh" onclick="loadTrends()">↻ Refresh</button>
-            </div>
-          </div>
-          <div id="trendList" style="margin-top:12px"><div class="empty-state">กำลังโหลดเทรนด์...</div></div>
+          <div class="trend-grid" id="trendList"><div class="empty-state" style="grid-column:1/-1">กำลังโหลด...</div></div>
         </div>
       </div>
 
@@ -981,36 +978,44 @@
 
     // Trends
     async function loadTrends() {
-      const el = document.getElementById('trendList');
-      el.innerHTML = '<div class="empty-state">กำลังโหลดเทรนด์...</div>';
+      var el = document.getElementById('trendList');
+      el.innerHTML = '<div class="empty-state" style="grid-column:1/-1">กำลังโหลด...</div>';
       try {
-        const r = await fetch('/api/trends', { credentials: 'same-origin' });
-        const d = await r.json();
-        const trends = d.trends || [];
-        const countEl = document.getElementById('trendCount');
-        const updEl = document.getElementById('trendUpdated');
-        if (countEl) countEl.textContent = '(' + trends.length + ' รายการ)';
-        if (updEl) updEl.textContent = 'อัพเดต: ' + new Date().toLocaleTimeString('th-TH', {hour:'2-digit',minute:'2-digit'});
-        if (!trends.length) { el.innerHTML = '<div class="empty-state">ไม่มีเทรนด์</div>'; return; }
-        el.innerHTML = trends.map((t, i) => {
-          const isHot = i < 3 ? ' hot' : '';
-          const hashtag = '#' + (t.title||'').replace(/\s+/g, '').replace(/[^\u0E00-\u0E7Fa-zA-Z0-9]/g,'');
-          const src=t.source||'google';const srcBadge=src==='x'?'<span style="font-size:0.6rem;padding:1px 6px;border-radius:3px;background:rgba(29,155,240,0.12);color:#1d9bf0;margin-left:4px">X</span>':'<span style="font-size:0.6rem;padding:1px 6px;border-radius:3px;background:rgba(66,133,244,0.12);color:#4285f4;margin-left:4px">Google</span>';const cat=t.category||'general';return `<div class="trend-item" data-cat="${cat}"><div class="trend-rank${isHot}">${i+1}</div><div class="trend-body"><div class="trend-title">${t.title}${srcBadge}</div><div class="trend-vol">${t.traffic||''}</div></div><div style="display:flex;gap:4px"><button class="trend-btn" onclick="useTrendHashtag('${hashtag.replace(/'/g,'')}')" title="เพิ่ม hashtag" style="font-size:0.7rem;padding:4px 8px">#</button><button class="trend-btn" onclick="useTrend(this)" data-topic="${(t.title||'').replace(/"/g,'&quot;')}">เขียนโพส →</button></div></div>`;
+        var r = await fetch('/api/shopee-trends', { credentials: 'same-origin' });
+        var d = await r.json();
+        var products = d.products || d.items || [];
+        var countEl = document.getElementById('trendCount');
+        if (countEl) countEl.textContent = '(' + products.length + ' สินค้า)';
+        if (!products.length) { el.innerHTML = '<div class="empty-state" style="grid-column:1/-1">ไม่มีข้อมูลสินค้า</div>'; return; }
+        el.innerHTML = products.map(function(p) {
+          var price = p.price_min && p.price_max && p.price_min !== p.price_max
+            ? '฿' + Number(p.price_min).toLocaleString() + ' - ฿' + Number(p.price_max).toLocaleString()
+            : '฿' + Number(p.price || p.price_min || 0).toLocaleString();
+          var stars = '';
+          var rating = p.rating || 0;
+          for (var s = 0; s < 5; s++) stars += s < Math.round(rating) ? '★' : '☆';
+          var sold = p.sold || p.historical_sold || 0;
+          var soldStr = sold >= 1000 ? (sold/1000).toFixed(1) + 'k' : String(sold);
+          var cat = p.category || 'general';
+          var img = p.image || p.thumbnail || '';
+          var url = p.url || p.link || '#';
+          var name = (p.name || p.title || '').replace(/</g, '&lt;');
+          return '<div class="trend-card" data-cat="' + cat + '">' +
+            (img ? '<img class="trend-card-img" src="' + img + '" alt="" loading="lazy" onerror="this.style.display=\'none\'">' : '<div class="trend-card-img" style="display:flex;align-items:center;justify-content:center;color:var(--text-muted);font-size:2rem">🛒</div>') +
+            '<div class="trend-card-body">' +
+              '<div class="trend-card-name">' + name + '</div>' +
+              '<div class="trend-card-price">' + price + '</div>' +
+              '<div class="trend-card-meta">' +
+                '<span class="trend-card-stars">' + stars + ' ' + rating.toFixed(1) + '</span>' +
+                '<span class="trend-card-sold">ขายแล้ว ' + soldStr + '</span>' +
+              '</div>' +
+            '</div>' +
+            '<a href="' + url + '" target="_blank" rel="noopener" class="trend-card-btn" onclick="event.stopPropagation()">ดูสินค้า →</a>' +
+          '</div>';
         }).join('');
-      } catch { el.innerHTML = '<div class="empty-state">โหลดไม่สำเร็จ</div>'; }
+      } catch(e) { el.innerHTML = '<div class="empty-state" style="grid-column:1/-1">โหลดไม่สำเร็จ</div>'; }
     }
-    function useTrendHashtag(tag) {
-      const ta = document.getElementById('message');
-      ta.value = ta.value.trim() + (ta.value.trim() ? '\n' : '') + tag + ' ';
-      document.getElementById('charCount').textContent = ta.value.length;
-    }
-    function useTrend(el) {
-      const topic = el.dataset.topic;
-      const hashtag = '#' + topic.replace(/\s+/g, '').replace(/[^\u0E00-\u0E7Fa-zA-Z0-9]/g,'');
-      document.getElementById('message').value = topic + '\n\n' + hashtag + '\n';
-      document.getElementById('charCount').textContent = document.getElementById('message').value.length;
-      switchTab('compose', document.querySelector('.sidebar-nav-item'));
-    }
+
 
     // Schedule
     function toggleSchedule() {
@@ -1671,7 +1676,7 @@
     function filterTrends(cat) {
       document.querySelectorAll('.trend-filter').forEach(b=>{b.style.background='var(--bg-input)';b.style.color='var(--text-secondary)';});
       event.target.style.background='var(--accent)';event.target.style.color='#fff';
-      document.querySelectorAll('.trend-item').forEach(el=>{
+      document.querySelectorAll('.trend-card').forEach(el=>{
         if(cat==='all'||el.dataset.cat===cat) el.style.display='';
         else el.style.display='none';
       });

--- a/src/routes/shopee-trends.ts
+++ b/src/routes/shopee-trends.ts
@@ -1,0 +1,99 @@
+import { Hono } from "hono";
+import { Env, getSessionFromReq, kvCache } from "../helpers";
+
+const shopee = new Hono<{ Bindings: Env }>();
+
+type ShopeeItem = {
+  name: string;
+  image: string;
+  price_min: number;
+  price_max: number;
+  sold: number;
+  rating: number;
+  reviews: number;
+  category: string;
+  shop_name: string;
+  link: string;
+};
+
+// Shopee Thailand category IDs
+const CATEGORIES: { id: number; name: string; keyword: string }[] = [
+  { id: 11044546, name: "fashion", keyword: "แฟชั่น" },
+  { id: 11044543, name: "electronics", keyword: "อิเล็กทรอนิกส์" },
+  { id: 11044534, name: "beauty", keyword: "บิวตี้" },
+  { id: 11044548, name: "home", keyword: "บ้าน" },
+  { id: 11044553, name: "health", keyword: "สุขภาพ" },
+];
+
+// GET /api/shopee-trends
+shopee.get("/shopee-trends", async (c) => {
+  const session = await getSessionFromReq(c);
+  if (!session) return c.json({ error: "Not authenticated" }, 401);
+
+  const categoryFilter = c.req.query("category");
+
+  try {
+    const data = await kvCache(c.env.KV, "shopee:trending:v1", 900, async () => {
+      const results = await Promise.all(
+        CATEGORIES.map((cat) => fetchShopeeCategory(cat))
+      );
+      const all = results.flat();
+      return { items: all, updated_at: new Date().toISOString() };
+    });
+
+    let filtered = data.items;
+    if (categoryFilter && categoryFilter !== "all") {
+      filtered = filtered.filter((item: ShopeeItem) => item.category === categoryFilter);
+    }
+
+    return c.json({ items: filtered, total: filtered.length, updated_at: data.updated_at });
+  } catch {
+    return c.json({ items: [], total: 0, updated_at: null });
+  }
+});
+
+async function fetchShopeeCategory(cat: { id: number; name: string; keyword: string }): Promise<ShopeeItem[]> {
+  const items: ShopeeItem[] = [];
+  try {
+    const url = `https://shopee.co.th/api/v4/search/search_items?by=sales&order=desc&limit=30&newest=0&match_id=${cat.id}`;
+    const res = await fetch(url, {
+      headers: {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        "Accept": "application/json",
+        "Accept-Language": "th-TH,th;q=0.9",
+        "Referer": "https://shopee.co.th/",
+      },
+    });
+    if (!res.ok) return items;
+    const data: any = await res.json();
+    const searchItems = data?.items || data?.item || [];
+
+    for (const raw of searchItems.slice(0, 30)) {
+      const item = raw?.item_basic || raw;
+      if (!item?.name) continue;
+
+      const shopId = item.shopid || item.shop_id || 0;
+      const itemId = item.itemid || item.item_id || 0;
+      const imageHash = item.image || "";
+      const image = imageHash
+        ? `https://down-th.img.susercontent.com/file/${imageHash}`
+        : "";
+
+      items.push({
+        name: item.name,
+        image,
+        price_min: (item.price_min || item.price || 0) / 100000,
+        price_max: (item.price_max || item.price || 0) / 100000,
+        sold: item.sold || item.historical_sold || 0,
+        rating: item.item_rating?.rating_star || 0,
+        reviews: item.item_rating?.rating_count?.[0] || item.cmt_count || 0,
+        category: cat.name,
+        shop_name: item.shop_name || "",
+        link: `https://shopee.co.th/product/${shopId}/${itemId}`,
+      });
+    }
+  } catch {}
+  return items;
+}
+
+export default shopee;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,6 +12,7 @@ import media from "./routes/media";
 import rss from "./routes/rss";
 import tickets from "./routes/tickets";
 import trends from "./routes/trends";
+import shopee from "./routes/shopee-trends";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -70,6 +71,7 @@ app.route("/api", media);
 app.route("/api", rss);
 app.route("/api", tickets);
 app.route("/api", trends);
+app.route("/api", shopee);
 
 // Alias routes (frontend uses different paths)
 app.post("/api/post/schedule", async (c) => {


### PR DESCRIPTION
## Summary
- เปลี่ยน UI เทรนด์จากรายการข้อความ → **product card grid**
- Product card: รูปสินค้า, ชื่อ (2 บรรทัด), ราคา (Shopee orange), rating ดาว, ยอดขาย, ปุ่มดูสินค้า
- Tab: ทั้งหมด / แฟชั่น / อิเล็กทรอนิกส์ / บิวตี้ / บ้าน / สุขภาพ
- Responsive: 2col mobile → 3col tablet → 4col desktop
- เรียก `/api/shopee-trends` (Sati's API)

## Test plan
- [ ] เปิด fb.makeloops.xyz → เทรนด์ → ต้องเห็น product card grid
- [ ] กด tab แฟชั่น/บิวตี้ → filter ถูก category
- [ ] มือถือ 2 คอลัมน์ / desktop 4 คอลัมน์
- [ ] กดปุ่ม "ดูสินค้า →" → เปิด link ในแท็บใหม่
- [ ] ถ้า API ยังไม่พร้อม → แสดง "ไม่มีข้อมูลสินค้า"

Closes xToriMicz/Jingjing-oracle#12

🤖 Generated with [Claude Code](https://claude.com/claude-code)