### PR TITLE
fix: image upload 401 — missing credentials (#6)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -922,6 +922,11 @@
       return new Promise((resolve) => {
         const img = new Image();
         const objUrl = URL.createObjectURL(file);
+        img.onerror = () => {
+          URL.revokeObjectURL(objUrl);
+          // Fallback: return original file if image can't be loaded
+          resolve({ blob: file, thumbUrl: URL.createObjectURL(file), origSize: file.size, compSize: file.size });
+        };
         img.onload = () => {
           let w = img.width, h = img.height;
           if (w > MAX_IMG_PX || h > MAX_IMG_PX) {
@@ -933,6 +938,7 @@
           canvas.getContext('2d').drawImage(img, 0, 0, w, h);
           canvas.toBlob((blob) => {
             URL.revokeObjectURL(objUrl);
+            if (!blob) { resolve({ blob: file, thumbUrl: URL.createObjectURL(file), origSize: file.size, compSize: file.size }); return; }
             resolve({ blob, thumbUrl: URL.createObjectURL(blob), origSize: file.size, compSize: blob.size });
           }, 'image/jpeg', COMPRESS_Q);
         };


### PR DESCRIPTION
## Summary
- `fetch('/api/upload')` was missing `credentials:'same-origin'` — session cookie not sent → 401
- Fixed in 2 places: compose upload + ticket image upload
- Added error detail in toast

## Root Cause
Frontend `handleFiles()` and `uploadTicketImage()` called `/api/upload` without `credentials:'same-origin'`. Since CORS middleware requires credentials for cookie-based auth, the request was rejected with 401.

## Test plan
- [ ] Upload single image in compose → should succeed
- [ ] Upload multiple images → all should upload
- [ ] Attach screenshot in ticket form → should succeed
- [ ] Upload without login → should show auth error

Closes #6