### PR TITLE
fix: bulk schedule fails — missing page_id + cron crash (#16)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1775,6 +1775,7 @@
     async function bulkSchedule() {
       const checks = document.querySelectorAll('.bulk-draft-check:checked');
       const st = document.getElementById('bulkStatus');
+      if (!selectedPage) { st.textContent = 'กรุณาเลือกเพจก่อน'; st.className = 'toast err'; return; }
       if (checks.length === 0) { st.textContent = 'เลือกฉบับร่างก่อน'; st.className = 'toast err'; return; }
       const startInput = document.getElementById('bulkStartTime').value;
       if (!startInput) { st.textContent = 'กรุณาเลือกเวลาเริ่มต้น'; st.className = 'toast err'; return; }
@@ -1786,7 +1787,7 @@
         posts.push({ message: cb.dataset.msg, scheduled_at: schedAt.toISOString() });
       });
       try {
-        const r = await fetch('/api/schedule/bulk', { method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ posts }) });
+        const r = await fetch('/api/schedule/bulk', { method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ posts, page_id: selectedPage.id }) });
         const d = await r.json();
         if (d.ok) { st.textContent = 'ตั้งเวลา ' + d.scheduled + ' โพสสำเร็จ!'; st.className = 'toast ok'; loadSchedule(); loadBulkDrafts(); }
         else { st.textContent = d.error || 'Error'; st.className = 'toast err'; }

--- a/schema.sql
+++ b/schema.sql
@@ -3,6 +3,8 @@ CREATE TABLE IF NOT EXISTS posts (
   message TEXT,
   image_url TEXT,
   fb_post_id TEXT,
+  page_id TEXT,
+  user_fb_id TEXT,
   status TEXT DEFAULT 'posted',
   created_at TEXT NOT NULL
 );
@@ -42,6 +44,7 @@ CREATE TABLE IF NOT EXISTS scheduled_posts (
   scheduled_at TEXT NOT NULL,
   status TEXT NOT NULL DEFAULT 'pending',
   fb_post_id TEXT,
+  error_message TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_scheduled_status ON scheduled_posts(status, scheduled_at);

--- a/src/routes/schedule.ts
+++ b/src/routes/schedule.ts
@@ -107,16 +107,20 @@ export async function processScheduledPosts(env: Env) {
         result = await res.json();
       }
       if (result.error) {
-        await env.DB.prepare("UPDATE scheduled_posts SET status = 'failed' WHERE id = ?").bind(post.id).run();
+        await env.DB.prepare("UPDATE scheduled_posts SET status = 'failed', error_message = ? WHERE id = ?").bind(JSON.stringify(result.error).slice(0, 500), post.id).run();
       } else {
         const fbPostId = result.id || result.post_id || null;
         await env.DB.prepare("UPDATE scheduled_posts SET status = 'posted', fb_post_id = ? WHERE id = ?").bind(fbPostId, post.id).run();
-        await env.DB.prepare(
-          "INSERT INTO posts (message, image_url, fb_post_id, page_id, user_fb_id, status, created_at) VALUES (?, ?, ?, ?, ?, 'posted', ?)"
-        ).bind(post.message, post.image_url, fbPostId, post.page_id, post.user_fb_id, new Date().toISOString()).run();
+        try {
+          await env.DB.prepare(
+            "INSERT INTO posts (message, image_url, fb_post_id, page_id, user_fb_id, status, created_at) VALUES (?, ?, ?, ?, ?, 'posted', ?)"
+          ).bind(post.message, post.image_url, fbPostId, post.page_id, post.user_fb_id, new Date().toISOString()).run();
+        } catch {
+          // posts table insert is non-critical — scheduled_posts status already updated
+        }
       }
-    } catch {
-      await env.DB.prepare("UPDATE scheduled_posts SET status = 'failed' WHERE id = ?").bind(post.id).run();
+    } catch (e) {
+      await env.DB.prepare("UPDATE scheduled_posts SET status = 'failed', error_message = ? WHERE id = ?").bind(String(e).slice(0, 500), post.id).run();
     }
   }
 }


### PR DESCRIPTION
## Summary
- Frontend `bulkSchedule()` ไม่ได้ส่ง `page_id` → backend fallback KV → null → "No page selected" 400
- Cron handler INSERT INTO `posts` ด้วย columns ที่ไม่มีใน schema → catch marks 'failed' แม้ FB API สำเร็จ
- เพิ่ม `error_message` column เพื่อ debug ง่ายขึ้น

## Changes
1. `public/index.html` — เพิ่ม `page_id: selectedPage.id` + check `selectedPage` ก่อน bulk
2. `src/routes/schedule.ts` — แยก INSERT INTO posts เป็น try/catch ของตัวเอง + store error_message
3. `schema.sql` — เพิ่ม page_id, user_fb_id ใน posts + error_message ใน scheduled_posts

## Test plan
- [ ] Bulk schedule โพส 2-3 รายการ → สถานะ pending
- [ ] รอ cron → สถานะเปลี่ยนเป็น posted (ไม่ใช่ failed)
- [ ] ตรวจ error_message ว่าว่างเปล่า (ไม่มี error)
- [ ] Single schedule ยังทำงานปกติ

## Note
Production DB ต้อง ALTER TABLE เพิ่ม columns:
```sql
ALTER TABLE posts ADD COLUMN page_id TEXT;
ALTER TABLE posts ADD COLUMN user_fb_id TEXT;
ALTER TABLE scheduled_posts ADD COLUMN error_message TEXT;
```

Closes #16