### PR TITLE
fix: engagement per-page token from DB (#26)

### DIFF
--- a/src/routes/post.ts
+++ b/src/routes/post.ts
@@ -150,24 +150,23 @@ post.get("/posts", async (c) => {
 
   if (withEngagement && results.length > 0) {
     const encKey = c.env.TOKEN_ENCRYPTION_KEY || c.env.FB_APP_SECRET;
-    const token = await getUserPageToken(c.env.KV, session.fb_id, encKey);
-    if (token) {
-      const enriched = await Promise.all(results.map(async (post: any) => {
-        if (!post.fb_post_id) return { ...post, engagement: null };
-        const eng = await kvCache(c.env.KV, `eng:${post.fb_post_id}`, 300, async () => {
-          try {
-            const res = await fetch(
-              `https://graph.facebook.com/v25.0/${post.fb_post_id}?fields=reactions.summary(true),comments.summary(true),shares&access_token=${token}`
-            );
-            const data = await res.json() as any;
-            if (data.error) return null;
-            return { likes: data.reactions?.summary?.total_count || 0, comments: data.comments?.summary?.total_count || 0, shares: data.shares?.count || 0 };
-          } catch { return null; }
-        });
-        return { ...post, engagement: eng };
-      }));
-      return c.json({ posts: enriched, total: enriched.length, pages });
-    }
+    const enriched = await Promise.all(results.map(async (post: any) => {
+      if (!post.fb_post_id || !post.page_id) return { ...post, engagement: null };
+      const token = await getDecryptedPageToken(c.env.DB, session.fb_id, post.page_id, encKey);
+      if (!token) return { ...post, engagement: null };
+      const eng = await kvCache(c.env.KV, `eng:${post.fb_post_id}`, 300, async () => {
+        try {
+          const res = await fetch(
+            `https://graph.facebook.com/v25.0/${post.fb_post_id}?fields=reactions.summary(true),comments.summary(true),shares&access_token=${token}`
+          );
+          const data = await res.json() as any;
+          if (data.error) return null;
+          return { likes: data.reactions?.summary?.total_count || 0, comments: data.comments?.summary?.total_count || 0, shares: data.shares?.count || 0 };
+        } catch { return null; }
+      });
+      return { ...post, engagement: eng };
+    }));
+    return c.json({ posts: enriched, total: enriched.length, pages });
   }
   return c.json({ posts: results, total: results.length, pages });
 });


### PR DESCRIPTION
## Summary
- หน้าประวัติไม่แสดง engagement บางโพสต์ เพราะใช้ token จาก KV (เพจที่ selected อยู่เท่านั้น)
- เปลี่ยนเป็น `getDecryptedPageToken(DB)` ดึง token ต่อ page_id จาก DB
- ทุกโพสต์แสดง engagement ได้ไม่ว่า select เพจไหนอยู่

## Changes
- `src/routes/post.ts` — เปลี่ยน getUserPageToken(KV) → getDecryptedPageToken(DB) per post

## Test plan
- [ ] หน้าประวัติแสดง likes/comments/shares ทุกโพสต์
- [ ] โพสต์จากหลายเพจ → ทุกเพจมี engagement
- [ ] โพสต์เก่าไม่มี fb_post_id → แสดงปกติ ไม่พัง
- [ ] KV cache ยังทำงาน (ไม่เรียก FB API ซ้ำภายใน 5 นาที)

Closes #26