### PR TITLE
feat: show post type badge + thumbnail in scheduled list

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1606,15 +1606,28 @@
           var cancelBtn = s.status === 'pending' ? '<button onclick="event.stopPropagation();cancelSchedule(' + s.id + ')" style="background:none;border:1px solid rgba(239,68,68,0.3);color:#ef4444;padding:4px 10px;border-radius:6px;font-size:0.72rem;cursor:pointer;margin-left:8px">ยกเลิก</button>' : '';
           var pgColor = pageColors[s.page_id] || 'var(--text-muted)';
           var pageBadge = s.page_name ? '<div style="display:flex;align-items:center;gap:4px;margin-bottom:2px">' + (s.page_picture ? '<img src="' + insEsc(s.page_picture) + '" style="width:16px;height:16px;border-radius:50%;object-fit:cover">' : '<span style="width:16px;height:16px;border-radius:50%;background:' + pgColor + ';display:inline-block;flex-shrink:0"></span>') + '<span style="font-size:0.72rem;color:' + pgColor + ';font-weight:500">' + insEsc(s.page_name) + '</span></div>' : '';
+          var hasImage = s.image_url && s.image_url.trim() !== '';
+          var typeBadge = hasImage
+            ? '<span style="display:inline-flex;align-items:center;gap:3px;background:rgba(59,130,246,0.15);color:#60a5fa;padding:1px 6px;border-radius:4px;font-size:0.68rem;font-weight:500">🖼️ รูปภาพ</span>'
+            : '<span style="display:inline-flex;align-items:center;gap:3px;background:rgba(148,163,184,0.15);color:#94a3b8;padding:1px 6px;border-radius:4px;font-size:0.68rem;font-weight:500">📝 ข้อความ</span>';
+          var thumbnail = hasImage
+            ? '<img src="' + insEsc(s.image_url) + '" style="width:48px;height:48px;border-radius:6px;object-fit:cover;flex-shrink:0;border:1px solid var(--border)" onerror="this.style.display=\'none\'">'
+            : '';
+          var expandedImage = hasImage
+            ? '<div style="margin-top:8px"><img src="' + insEsc(s.image_url) + '" style="max-width:100%;max-height:200px;border-radius:8px;object-fit:contain;border:1px solid var(--border)" onerror="this.style.display=\'none\'"></div>'
+            : '';
           return '<div style="background:var(--bg-input);border-radius:8px;margin-bottom:6px;border-left:3px solid ' + pgColor + ';border:1px solid var(--border);border-left:3px solid ' + pgColor + ';cursor:pointer" onclick="this.querySelector(\'.sched-full\').style.display=this.querySelector(\'.sched-full\').style.display===\'block\'?\'none\':\'block\'">' +
-            '<div style="display:flex;justify-content:space-between;align-items:center;padding:10px 12px">' +
+            '<div style="display:flex;justify-content:space-between;align-items:center;padding:10px 12px;gap:10px">' +
               '<div style="flex:1;min-width:0">' +
                 pageBadge +
+                '<div style="display:flex;align-items:center;gap:6px;margin-bottom:2px">' + typeBadge + '</div>' +
                 '<div style="font-size:0.82rem;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + preview + '</div>' +
                 '<div style="font-size:0.72rem;color:var(--text-muted);margin-top:2px">📅 ' + dt + ' · <span style="color:' + stColor + '">' + stText + '</span></div>' +
-              '</div>' + cancelBtn +
+              '</div>' +
+              thumbnail +
+              cancelBtn +
             '</div>' +
-            '<div class="sched-full" style="display:none;padding:0 12px 10px;font-size:0.78rem;color:var(--text-secondary);white-space:pre-wrap;line-height:1.5;border-top:1px solid var(--border);margin:0 12px;padding-top:8px">' + msg + '</div>' +
+            '<div class="sched-full" style="display:none;padding:0 12px 10px;font-size:0.78rem;color:var(--text-secondary);white-space:pre-wrap;line-height:1.5;border-top:1px solid var(--border);margin:0 12px;padding-top:8px">' + msg + expandedImage + '</div>' +
           '</div>';
         }).join('');
       } catch(e) { list.innerHTML = '<div class="empty-state">Error</div>'; }


### PR DESCRIPTION
## Summary
- เพิ่ม badge แสดงชนิดโพส: 📝 ข้อความ / 🖼️ รูปภาพ ในรายการตั้งเวลา
- แสดง thumbnail 48x48 สำหรับโพสที่มีรูป
- คลิกขยายเห็นรูปใหญ่ + ข้อความเต็ม
- รูปโหลดไม่ได้ซ่อนอัตโนมัติ (onerror)

## Test plan
- [ ] เปิดหน้า ตั้งเวลา/Bulk ดูรายการที่ตั้งเวลาไว้
- [ ] โพสข้อความธรรมดา → ควรเห็น badge "📝 ข้อความ"
- [ ] โพสที่มีรูป → ควรเห็น badge "🖼️ รูปภาพ" + thumbnail ด้านขวา
- [ ] คลิกขยายโพสที่มีรูป → เห็นรูปใหญ่ด้านล่าง

🤖 Generated with [Claude Code](https://claude.com/claude-code)